### PR TITLE
Issue 5 - Run battery checks with higher frequency throughout the day.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+MagicPowerAlert.sh.log
+MagicPowerAlert.sh.mute

--- a/MagicPowerAlert.sh
+++ b/MagicPowerAlert.sh
@@ -27,7 +27,7 @@ INACTIVITY_THRESHOLD_MINS=5
 MESSAGE="Get a coffee and charge:\n"
 
 # set to 1, creates a log file for debugging. Log file is ./MagicPowerAlert.sh.log
-LOGFILE=1
+LOGFILE=0
 
 # Change nothing below here
 messages=()

--- a/MagicPowerAlert.sh
+++ b/MagicPowerAlert.sh
@@ -5,29 +5,87 @@
 # 2. Add a cron entry to run it, for example:
 #   30 9 * * * /Users/dougb/MagicPower/MagicPowerAlert.sh
 #
+# 3. Or, run frequently but set the muting and inactivity vars
+#   */30 * * * * /Users/dougb/MagicPower/MagicPowerAlert.sh
+#
+#   MUTE_CONSECUTIVE_ALERTS_HOURS=4
+#   INACTIVITY_THRESHOLD_MINS=5
 
-# You can monitor the battery levels and charging status by passing 'status' as
-# the first argument to the script
-getStatus="false"
-
-# You can change the default threshold by passing a value as the first argument to the script
+# You can change the default (20) threshold by passing a value as the first argument to the script
 THRESHOLD="${1:-20}"
 
-# Strip a percent sign in case the user supplied one
-THRESHOLD="${THRESHOLD/\%/}"
+# Set to mute consecutive alerts for a period of minutes. Makes it practical to schedule
+# MagicPowerAlert to run frequently, say every 30 minutes. Really, two alerts per day are
+# probably enough of a reminder. So a good value is maybe 4 hours.
+MUTE_CONSECUTIVE_ALERTS_HOURS=4
 
+# Inactivity detection. If user is afk, don't continue and possibly spam the desktop with alerts.
+# For example, no alerts during the night when running other automated tasks.
+INACTIVITY_THRESHOLD_MINS=5
+
+# You can change the message, if coffee is not your thing
+MESSAGE="Get a coffee and charge:\n"
+
+# set to 1, creates a log file for debugging. Log file is ./MagicPowerAlert.sh.log
+LOGFILE=1
+
+# Change nothing below here
+messages=()
+
+# Crude but simple logger to file.
+function logger() {
+    if [[ $LOGFILE -eq 1 ]]; then
+        echo "$(date) $1" >> ${BASH_SOURCE[0]}.log
+    fi
+}
+
+# Handler cli args. Strip a percent sign in case the user supplied one
+THRESHOLD="${THRESHOLD/\%/}"
 if [[ "$THRESHOLD" == "status" ]]; then
     getStatus="true"
 elif [[ "$THRESHOLD" -lt 1 ]] || [[ "$THRESHOLD" -gt 100 ]]; then
     echo "[!] Alert threshold must be between 1% and 100%" >&2
     exit 1
+else
+    getStatus="false"
 fi
 
-# You can change the message, if coffee is not your thing
-MESSAGE="Get a coffee and charge:\n"
+# Check for inactivity, exit if the user is away from keyboard. Skip if this is a cli status check.
+IOREG_IDLE=$(/usr/sbin/ioreg -k HIDIdleTime -a -r)
+inactivity=$(/usr/bin/xmllint --xpath "
+                /plist/
+                  array/
+                    dict/
+                      key[.='HIDIdleTime']/
+                      following-sibling::*[1]/
+                        text()" - 2>/dev/null <<< "$IOREG_IDLE")
+INACTIVITY_SECONDS=$(( $inactivity / 1000000000 ))
+INACTIVITY_MINUTES=$(( $INACTIVITY_SECONDS / 60 ))
 
-# Change nothing below here
-messages=()
+if [[ $INACTIVITY_MINUTES -ge $INACTIVITY_THRESHOLD_MINS && $getStatus != "true" ]]; then
+    logger "skip because of inactivity for $INACTIVITY_MINUTES m [threshold is $INACTIVITY_THRESHOLD_MINS m]"
+    exit 0
+fi
+
+# Clear out possible mute alerts file if expired, unless it's a cli status check.
+muteAlertsFileName="${BASH_SOURCE[0]}.mute"
+
+if [[ -f $muteAlertsFileName && $getStatus != "true" ]]; then
+    fileAgeInSeconds=$(($(date +%s) - $(stat -t %s -f %m -- "$muteAlertsFileName")))
+    fileAgeInMinutes=$((fileAgeInSeconds / 60))
+    fileAgeInHours=$((fileAgeInMinutes / 60))
+
+    if [[ $fileAgeInHours -ge $MUTE_CONSECUTIVE_ALERTS_HOURS ]]; then
+        logger "removing file $muteAlertsFileName"
+        rm $muteAlertsFileName
+    fi
+
+    if [[ $fileAgeInHours -lt $MUTE_CONSECUTIVE_ALERTS_HOURS ]]; then
+        logger "skip because muting active. file $muteAlertsFileName has age $fileAgeInMinutes m"
+        exit 0
+    fi
+fi
+
 
 # Gather XML data about devices reporting a 'BatteryPercent'
 IOREG=$(/usr/sbin/ioreg -r -a -k BatteryPercent 2>/dev/null)
@@ -107,7 +165,17 @@ if (( "$len" > 0 )); then
     else
         for index in ${!messages[*]}; do
             message="$message\n\t${messages[$index]}"
+            logger "alerting with ${messages[$index]}"
         done
+
+        # osascript is blocking, so create mute file here to signal subsequent runs to skip
+        # consecutive alerts.
+        touch $muteAlertsFileName
+        logger "created file $muteAlertsFileName"
+
+        # Interestingly, this osascript process only last for about 60s. even when it is still
+        # visible as a window alert. So we can't just grep for the process and use that method
+        # to mute consecutive alerts.
         /usr/bin/osascript -e "
             tell application \"System Events\"
                 activate

--- a/MagicPowerAlert.sh
+++ b/MagicPowerAlert.sh
@@ -8,8 +8,7 @@
 # 3. Or, run frequently but set the muting and inactivity vars
 #   */30 * * * * /Users/dougb/MagicPower/MagicPowerAlert.sh
 #
-#   MUTE_CONSECUTIVE_ALERTS_HOURS=4
-#   INACTIVITY_THRESHOLD_MINS=5
+VERSION="v1.1.0" # unused, but for info
 
 # You can change the default (20) threshold by passing a value as the first argument to the script
 THRESHOLD="${1:-20}"

--- a/MagicPowerAlert.sh
+++ b/MagicPowerAlert.sh
@@ -35,7 +35,7 @@ messages=()
 # Crude but simple logger to file.
 function logger() {
     if [[ $LOGFILE -eq 1 ]]; then
-        echo "$(date) $1" >> ${BASH_SOURCE[0]}.log
+        echo "$(date) $1" >> "${BASH_SOURCE[0]}.log"
     fi
 }
 
@@ -59,8 +59,8 @@ inactivity=$(/usr/bin/xmllint --xpath "
                       key[.='HIDIdleTime']/
                       following-sibling::*[1]/
                         text()" - 2>/dev/null <<< "$IOREG_IDLE")
-INACTIVITY_SECONDS=$(( $inactivity / 1000000000 ))
-INACTIVITY_MINUTES=$(( $INACTIVITY_SECONDS / 60 ))
+INACTIVITY_SECONDS=$(( inactivity / 1000000000 ))
+INACTIVITY_MINUTES=$(( INACTIVITY_SECONDS / 60 ))
 
 if [[ $INACTIVITY_MINUTES -ge $INACTIVITY_THRESHOLD_MINS && $getStatus != "true" ]]; then
     logger "skip because of inactivity for $INACTIVITY_MINUTES m [threshold is $INACTIVITY_THRESHOLD_MINS m]"
@@ -77,7 +77,7 @@ if [[ -f $muteAlertsFileName && $getStatus != "true" ]]; then
 
     if [[ $fileAgeInHours -ge $MUTE_CONSECUTIVE_ALERTS_HOURS ]]; then
         logger "removing file $muteAlertsFileName"
-        rm $muteAlertsFileName
+        rm "$muteAlertsFileName"
     fi
 
     if [[ $fileAgeInHours -lt $MUTE_CONSECUTIVE_ALERTS_HOURS ]]; then
@@ -170,7 +170,7 @@ if (( "$len" > 0 )); then
 
         # osascript is blocking, so create mute file here to signal subsequent runs to skip
         # consecutive alerts.
-        touch $muteAlertsFileName
+        touch "$muteAlertsFileName"
         logger "created file $muteAlertsFileName"
 
         # Interestingly, this osascript process only last for about 60s. even when it is still

--- a/README.md
+++ b/README.md
@@ -6,9 +6,6 @@ MagicPowerAlert lets you know at 20%, giving you lots of time to fit in a chargi
 
 Competency level: comfortable using Terminal, and cron.
 
-### Screencast
-I put up a [screencast](https://vimeo.com/413113839) running through how to install.
-
 ### Instructions:
 
 ##### Download Code
@@ -18,36 +15,41 @@ $ mkdir MagicPower
 $ cd MagicPower
 $ curl -L0 -O https://raw.githubusercontent.com/thisdougb/MagicPowerAlert/master/MagicPowerAlert.sh
 ```
+#### View Battery and Charging Status (without the pop-up alert)
+```
+$ ./MagicPowerAlert.sh status
+Magic Keyboard with Numeric Keypad at 98%
+Magic Mouse 2 at 47% (charging)
+```
 ##### Configure
 The default should be fine, it'll pick up either mouse or keyboard below 20% power.
 But you can change this is you like.
 
 ```
-$ head MagicPowerAlert.sh
-#!/usr/bin/env bash
+# Set to mute consecutive alerts for a period of minutes. Makes it practical to schedule
+# MagicPowerAlert to run frequently, say every 30 minutes. Really, two alerts per day are
+# probably enough of a reminder. So a good value is maybe 4 hours.
+MUTE_CONSECUTIVE_ALERTS_HOURS=4
 
-# You can change the default threshold of 20% by supplying an argument to the script
-THRESHOLD=20
+# Inactivity detection. If user is afk, don't continue and possibly spam the desktop with alerts.
+# For example, no alerts during the night when running other automated tasks.
+INACTIVITY_THRESHOLD_MINS=5
 
-# You can change the message here, if coffee is not your thing
+# You can change the message, if coffee is not your thing.
 MESSAGE="Get a coffee and charge:\n"
 ```
-
-#### Test
+#### Test Pop-up Alert
 Give it a quick test, set the alert THRESHOLD to 100 by supplying as an argument.
 A window prompt should pop-up, with your alert.
 ```
 $ chmod +x MagicPowerAlert.sh
 $ ./MagicPowerAlert.sh 100
 ```
-
-#### View Battery and Charging Status (without the popup alert)
+Remember that running while muted will not pop-up an alert. So just remove this file if you want to re-test.
 ```
-$ ./MagicPowerAlert.sh status
-Magic Keyboard with Numeric Keypad at 98%
-Magic Mouse 2 at 47% (charging)
+$ ls -l MagicPowerAlert.sh.mute
+-rw-r--r--  1 dougb  staff  0  4 Apr 11:29 MagicPowerAlert.sh.mute
 ```
-
 #### Schedule It
 If you haven't used cron before, then the relevant info (from 'man 5 cron') is:
 ```
@@ -61,23 +63,22 @@ The time and date fields are:
        month         1-12 (or names, see below)
        day of week   0-7 (0 or 7 is Sun, or use names)
 
- A field may be an asterisk (*), which always stands for ``first-last''.
+A field may be an asterisk (*), which always stands for first-last.
 
- Ranges of numbers are allowed.  Ranges are two numbers separated with a hyphen.  The specified range is inclu-
- sive.  For example, 8-11 for an ``hours'' entry specifies execution at hours 8, 9, 10 and 11.
+To specific a range use 9-12, which gives 9, 10, 11, 12.
 
- Lists are allowed.  A list is a set of numbers (or ranges) separated by commas.  Examples: ``1,2,5,9'',
- ``0-4,8-12''.
+To step through a range use */<step>, for example */5 will give 0, 5, 10, etc.
 ```
-Add an entry similar to this, but with your path and time preferences.
-This runs every morning at 09:30:
+Add a cron entry with your file path and time preferences.
+To avoid waking up to a hundred pop-up alerts, ensure you configure muting and inactivity to suitable values.
+
+For example, this runs every 30 minutes:
 ```
-30 9 * * * /Users/dougb/dev/scripts/MagicPowerAlert.sh
+*/30 * * * * /Users/dougb/dev/MagicPowerAlert/MagicPowerAlert.sh
 ```
 #### Switch Off
 Of course you can delete the cron entry, or simply comment it out.
 ```
 # switched off
-#30 9 * * * /Users/dougb/dev/scripts/MagicPowerAlert.sh
+#*/30 * * * * /Users/dougb/dev/MagicPowerAlert/MagicPowerAlert.sh
 ```
-

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ $ ./MagicPowerAlert.sh status
 Magic Keyboard with Numeric Keypad at 98%
 Magic Mouse 2 at 47% (charging)
 ```
-##### Configure
+#### Configure
 The default should be fine, it'll pick up either mouse or keyboard below 20% power.
 But you can change this is you like.
 


### PR DESCRIPTION
Now I can run every 30 minutes or so, so I don't have to be logged in at a set time to get the alert. Alerts can be muted to avoid pop-up spam, and it won't run if I'm not using the Mac.

The debug log is pretty handy too.

Adds:
* debug log file toggle
* skips alerting if user inactive (away from keyboard), defaults 5 mins.
* configurable to mute pop-up alerts for a given period, default 4 hours after first alert.
* some refactoring by moving code chunks around to keep it easy to read/follow.

closes #5 